### PR TITLE
Update QIP-244 status to Approved and reverse proposal sorting in AllProposals component

### DIFF
--- a/contents/QIP/QIP-244.md
+++ b/contents/QIP/QIP-244.md
@@ -2,7 +2,7 @@
 qip: 244  
 title: Q4 Interest Rate Changes  
 network: All Chains  
-status: Draft  
+status: Approved  
 author: 0xNacho  
 implementor: "Guardians"  
 implementation-date: Post-approval  

--- a/src/pages/all-proposals.tsx
+++ b/src/pages/all-proposals.tsx
@@ -37,9 +37,7 @@ const AllProposals: React.FC<Props> = ({
                         <div className="mb-16"></div>
 
                         {columns.map((column: any) => {
-                            const proposals = sortBy('frontmatter.qip')(
-                                column.nodes
-                            );
+                            const proposals = sortBy("frontmatter.qip", column.nodes).reverse();
                             return (
                                 <div
                                     key={column.fieldValue}


### PR DESCRIPTION
Change the status of QIP-244 to Approved and modify the sorting order of proposals in the AllProposals component.